### PR TITLE
fix: .snyk & package.json to reduce vulnerabilities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,11 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.10.2
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  'npm:hawk:20160119':
+    - tap > codecov.io > request > hawk:
+        patched: '2018-04-27T15:30:41.433Z'
+  'npm:request:20160119':
+    - tap > codecov.io > request:
+        patched: '2018-04-27T15:30:41.433Z'

--- a/package.json
+++ b/package.json
@@ -10,31 +10,35 @@
   "scripts": {
     "start": "node app.js",
     "build": "browserify -r jquery > public/js/bundle.js",
-    "cleanup": "mongo express-todo --eval 'db.todos.remove({});'"
+    "cleanup": "mongo express-todo --eval 'db.todos.remove({});'",
+    "snyk-protect": "snyk protect",
+    "prepare": "npm run snyk-protect"
   },
   "dependencies": {
-    "body-parser": "1.9.0",
+    "body-parser": "1.17.1",
     "cookie-parser": "1.3.3",
-    "ejs": "1.0.0",
+    "ejs": "2.5.5",
     "ejs-locals": "1.0.2",
-    "errorhandler": "1.2.0",
-    "express": "4.12.4",
+    "errorhandler": "1.4.3",
+    "express": "4.16.0",
     "express-fileupload": "0.0.5",
-    "humanize-ms": "1.0.1",
-    "jquery": "^2.2.4",
-    "marked": "0.3.5",
+    "humanize-ms": "1.2.1",
+    "jquery": "^3.0.0",
+    "marked": "0.3.17",
     "method-override": "latest",
-    "moment": "2.15.1",
-    "mongoose": "4.2.4",
+    "moment": "2.19.3",
+    "mongoose": "4.11.14",
     "morgan": "latest",
-    "ms": "^0.7.1",
-    "npmconf": "0.0.24",
+    "ms": "^2.0.0",
+    "npmconf": "2.0.9",
     "optional": "^0.1.3",
-    "st": "0.2.4",
+    "st": "1.2.2",
     "stream-buffers": "^3.0.1",
-    "tap": "^5.7.0"
+    "tap": "^11.1.3",
+    "snyk": "^1.74.0"
   },
   "devDependencies": {
     "browserify": "^13.1.1"
-  }
+  },
+  "snyk": true
 }


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- http://localhost:8000/vuln/npm:braces:20180219
- http://localhost:8000/vuln/npm:bson:20180225
- http://localhost:8000/vuln/npm:debug:20170905
- http://localhost:8000/vuln/npm:ejs:20161128
- http://localhost:8000/vuln/npm:ejs:20161130
- http://localhost:8000/vuln/npm:ejs:20161130-1
- http://localhost:8000/vuln/npm:fresh:20170908
- http://localhost:8000/vuln/npm:hoek:20180212
- http://localhost:8000/vuln/npm:jquery:20150627
- http://localhost:8000/vuln/npm:marked:20150520
- http://localhost:8000/vuln/npm:marked:20170112
- http://localhost:8000/vuln/npm:marked:20170815
- http://localhost:8000/vuln/npm:marked:20170815-1
- http://localhost:8000/vuln/npm:marked:20170907
- http://localhost:8000/vuln/npm:marked:20180225
- http://localhost:8000/vuln/npm:mime:20170907
- http://localhost:8000/vuln/npm:moment:20161019
- http://localhost:8000/vuln/npm:moment:20170905
- http://localhost:8000/vuln/npm:mongoose:20160116
- http://localhost:8000/vuln/npm:ms:20151024
- http://localhost:8000/vuln/npm:ms:20170412
- http://localhost:8000/vuln/npm:negotiator:20160616
- http://localhost:8000/vuln/npm:qs:20170213
- http://localhost:8000/vuln/npm:semver:20150403
- http://localhost:8000/vuln/npm:st:20140206
- http://localhost:8000/vuln/npm:st:20171013
- http://localhost:8000/vuln/npm:tunnel-agent:20170305


The following vulnerabilities are fixed with a Snyk patch:
- http://localhost:8000/vuln/npm:hawk:20160119
- http://localhost:8000/vuln/npm:request:20160119